### PR TITLE
Update tags.html with more undocumented tags from the conversation today (yesterday?)

### DIFF
--- a/teardown/tags.html
+++ b/teardown/tags.html
@@ -34,9 +34,21 @@
 		</dd>
 		<dt id="tags-boat"><code>boat</code></dt>
 		<dd>
-			Vehicle tag. Makes vehicle a boat, with additional boat physics applied ane able to use propeller locations, but lose ability to use wheel.
+			Vehicle tag. Makes vehicle a boat, with additional boat physics applied and able to use <code>propeller</code> locations, but lose ability to use wheel.
 			<br/>
 			<span class="alert-added">Added in 0.5.1 (5987914).</span>
+		</dd>
+		<dt id="tags-bomb"><code>bomb=<u>time</u> (TODO: verify)</code></dt>
+		<dd>
+			Shape tag. Will countdown the time untill it reaches 0, which then the shape is exploded (TODO: shape pivot? shape center?) and removed (TODO: verify, and which order?), time in seconds (TODO: verify). This is used/set/handled by the engine for bombs and pipebombs.
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
+		</dd>
+		<dt id="tags-bombstrength"><code>bombstrength=<u>size</u> (TODO: verify)</code></dt>
+		<dd>
+			Shape tag. Used as explosion size by <code>bomb</code> tag, "size" is number in range 0.5 to 4 (TODO: verify). This is used/set/handled by the engine for bombs and pipebombs.
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
 		</dd>
 		<dt id="tags-breakall"><code>breakall</code></dt>
 		<dd>
@@ -58,6 +70,22 @@
 			<br/>
 			<span class="alert-undocumented">This tag is not officially documented.</span>
 		</dd>
+		<dt id="tags-cranebottom"><code>cranebottom</code></dt>
+		<dd>
+			Vehicle tag. All hinge joints on vehicle are controllable with vehicle_raise/vehicle_lower (TODO: verify), display crane base (TODO: better name) controls.
+			<br/>
+			<span class="alert-added">Added in 0.9.0 (7801522).</span>
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
+		</dd>
+		<dt id="tags-cranetop"><code>cranetop</code></dt>
+		<dd>
+			Vehicle tag. display crane arm controls. (TODO: any joint magic?)
+			<br/>
+			<span class="alert-added">Added in 0.9.0 (7801522).</span>
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
+		</dd>
 		<dt id="tags-dumptruck"><code>dumptruck</code></dt>
 		<dd>
 			Vehicle tag. All hinge joints on vehicle are controllable with vehicle_raise/vehicle_lower, display bed controls.
@@ -74,7 +102,15 @@
 		</dd>
 		<dt id="tags-explosive"><code>explosive=<u>size</u></code></dt>
 		<dd>
-			Body and shape tag. Entity explodes when broken. "size" is number in range 0.5 to 4 (TODO: verify). If applied to an already broken shape, it instantly blows up.
+			Body and shape tag. Entity explodes when broken. "size" is number in range 0.5 to 4. If applied to an already broken shape, it instantly blows up.
+		</dd>
+		<dt id="tags-extend"><code>extend</code></dt>
+		<dd>
+			Joint tag. Joint can be controlled by up/down when player in <code>crane</code> (TODO: verify) vehicle.
+			<br/>
+			<span class="alert-added">Added in 0.9.0 (7801522).</span>
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
 		</dd>
 		<dt id="tags-forklift"><code>forklift</code></dt>
 		<dd>
@@ -134,6 +170,12 @@
 			<br/>
 			<span class="alert-added">Added in 1.3.0 (10148769).</span>
 		</dd>
+		<dt id="tags-level"><code>level</code></dt>
+		<dd>
+			Joint tag. Force skylift joints to have the same rotation amount.
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
+		</dd>
 		<dt id="tags-map"><code>map</code></dt>
 		<dd>
 			Body tag. Marks body on map. Defaults to a blue color. Handled by <code>data/ui/map.lua</code>. Non-engine.
@@ -152,7 +194,7 @@
 		</dd>
 		<dt id="tags-nodrive"><code>nodrive</code></dt>
 		<dd>
-			Vehicle tag. Vehicle is not drivable to the player
+			Vehicle tag. Vehicle is not drivable to the player with no "Drive" promp.
 		</dd>
 		<dt id="tags-nonav"><code>nonav</code></dt>
 		<dd>
@@ -170,9 +212,23 @@
 			<br/>
 			<span class="alert-undocumented">This tag is not officially documented.</span>
 		</dd>
+		<dt id="tags-passive"><code>passive</code></dt>
+		<dd>
+			Vehicle tag. Disable inputs to the vehicle so it does not drive, stear or gear change (TODO: verify) and leaves only the engine idle sounds.
+			<br/>
+			<span class="alert-added">Added in 0.9.0 (7801522) (TODO: verify).</span>
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
+		</dd>
 		<dt id="tags-player"><code>player</code></dt>
 		<dd>
 			Location tag. Defines where the entry point and first person camera are for a vehicle.
+		</dd>
+		<dt id="tags-plank"><code>plank</code></dt>
+		<dd>
+			Joint tag. Don't know what it does engine wise, but this tag means that this joint is supposed to be a plank joint.
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
 		</dd>
 		<dt id="tags-propeller"><code>propeller</code></dt>
 		<dd>
@@ -190,6 +246,12 @@
 			<br/>
 			<span class="alert-undocumented">This tag is not officially documented.</span>
 		</dd>
+		<dt id="tags-smoke"><code>smoke</code></dt>
+		<dd>
+			Shape tag. emit smoke from shape, This is used/set/handled by the engine for pipebombs.
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
+		</dd>
 		<dt id="tags-tank"><code>tank</code></dt>
 		<dd>
 			Vehicle tag. Display tank controls. Handled by <code>data/script/tank.lua</code> and <code>data/ui/hud.lua</code>. Non-engine.
@@ -198,13 +260,29 @@
 			<br/>
 			<span class="alert-undocumented">This tag is not officially documented.</span>
 		</dd>
+		<dt id="tags-turn"><code>turn</code></dt>
+		<dd>
+			Joint tag. Force Joint to be controlled by left/right when player in <code>crane</code> (TODO: verify) vehicle.
+			<br/>
+			<span class="alert-added">Added in 0.9.0 (7801522).</span>
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
+		</dd>
 		<dt id="tags-unbreakable"><code>unbreakable</code></dt>
 		<dd>
-			Body and shape tag. Entity unbreakable, but still markable by spray paint or burn marks.
+			Body, shape, and rope type joint tag. Entity unbreakable, but still markable by spray paint or burn marks.
 		</dd>
 		<dt id="tags-vital"><code>vital</code></dt>
 		<dd>
 			Location tag. When voxels at this position are broken, the vehicle is instantly broken (TODO: verify). Defines where engine smoke comes from.
+			<br/>
+			<span class="alert-undocumented">This tag is not officially documented.</span>
+		</dd>
+		<dt id="tags-wire"><code>wire</code></dt>
+		<dd>
+			Joint tag. Don't know what it does engine wise, but this tag means that this joint is supposed to be a wire joint.
+			<br/>
+			<span class="alert-added">Added in 0.9.0 (7801522).</span>
 			<br/>
 			<span class="alert-undocumented">This tag is not officially documented.</span>
 		</dd>


### PR DESCRIPTION
new tags are:
- bomb=time
- bombstrength=size
- cranebottom
- cranetop
- extend
- level
- passive
- plank
- smoke
- turn
- wire

changed tag desc are:
- boat (fix typo)
- explosive (comfirmed size)
- nodrive (detailed behaviour)
- unbreakable (included rope)

